### PR TITLE
fix: use Nodejs 16 to build front-end

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -24,6 +24,10 @@ jobs:
       - name: checkout the repo and building the Backend
         uses: actions/checkout@v2
 
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -26,6 +26,10 @@ jobs:
       - name: checkout the repo and building the Backend
         uses: actions/checkout@v2
 
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:


### PR DESCRIPTION
# Fixing build of front end
The front-end building didn't work on the last version of nodeJS (18)
By forcing the version 16 the deployement works

*ATTENTION* The code of the lambda is actually broken and the interaction on the site doesn't work.

## Test
- [x] terraform plan
- [x] terraform apply
- [x] terraform destroy
- [x] Access to the website
- [ ] *Broken* interaction with the the greetings 