### PR TITLE
Vars from secrets

### DIFF
--- a/.github/workflows/AutomationTestUbuntu.yml
+++ b/.github/workflows/AutomationTestUbuntu.yml
@@ -4,8 +4,8 @@
 name: Run Automated test Ubuntu
 
 env:
-      LICENSE_PLATE: ${{ variables.LICENSEPLATE }} 
-      BASEURL:   ${{ variables.BASEURL }} 
+      LICENSE_PLATE: ${{ vars.LICENSEPLATE }} 
+      BASEURL:   ${{ vars.BASEURL }} 
       
 on:
     workflow_dispatch:

--- a/.github/workflows/AutomationTestUbuntu.yml
+++ b/.github/workflows/AutomationTestUbuntu.yml
@@ -4,8 +4,8 @@
 name: Run Automated test Ubuntu
 
 env:
-      LICENSE_PLATE: ${{ secrets.MY_LICENSE_PLATE }} 
-      BASEURL:   ${{ secrets.BASEURL }} 
+      LICENSE_PLATE: ${{ variables.LICENSEPLATE }} 
+      BASEURL:   ${{ variables.BASEURL }} 
       
 on:
     workflow_dispatch:

--- a/.github/workflows/browserStackTest.yml
+++ b/.github/workflows/browserStackTest.yml
@@ -1,9 +1,6 @@
 
 name: BrowserStack Test
 
-env:  
-     LICENSE_PLATE: ${{ secrets.MY_LICENSE_PLATE }}
-
 
 on: 
   workflow_dispatch:

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -27,16 +27,16 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          role-to-assume: ${{ secrets.TERRAFORM_DEPLOY_ROLE_ARN }}
+          role-to-assume: ${{ variables.TERRAFORM_DEPLOY_ROLE_ARN }}
           aws-region: ca-central-1
 
       - name: destroying the  back-end using terraform
         run: |
           cd server
           cat <<EOF > backend.hcl
-          bucket = "${{ secrets.S3_BACKEND_NAME }}"
-          key = "${{ secrets.LICENCEPLATE }}/${{ env.environment }}/serverless-app.tfstate"
-          dynamodb_table = "terraform-remote-state-lock-${{ secrets.LICENCEPLATE }}"
+          bucket = "${{ variables.S3_BACKEND_NAME }}"
+          key = "${{ variables.LICENSEPLATE }}/${{ env.environment }}/serverless-app.tfstate"
+          dynamodb_table = "terraform-remote-state-lock-${{ variables.LICENSEPLATE }}"
           EOF
           terraform init -backend-config=backend.hcl
           terraform destroy -auto-approve
@@ -45,9 +45,9 @@ jobs:
         run: |
           cd client
           cat <<EOF > backend.hcl
-          bucket = "${{ secrets.S3_BACKEND_NAME }}"
-          key = "${{ secrets.LICENCEPLATE }}/${{ env.environment }}/serverless-app.tfstate"
-          dynamodb_table = "terraform-remote-state-lock-${{ secrets.LICENCEPLATE }}"
+          bucket = "${{ variables.S3_BACKEND_NAME }}"
+          key = "${{ variables.LICENSEPLATE }}/${{ env.environment }}/serverless-app.tfstate"
+          dynamodb_table = "terraform-remote-state-lock-${{ variables.LICENSEPLATE }}"
           EOF
           terraform init -backend-config=backend.hcl
           terraform destroy -auto-approve

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -27,16 +27,16 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          role-to-assume: ${{ variables.TERRAFORM_DEPLOY_ROLE_ARN }}
+          role-to-assume: ${{ vars.TERRAFORM_DEPLOY_ROLE_ARN }}
           aws-region: ca-central-1
 
       - name: destroying the  back-end using terraform
         run: |
           cd server
           cat <<EOF > backend.hcl
-          bucket = "${{ variables.S3_BACKEND_NAME }}"
-          key = "${{ variables.LICENSEPLATE }}/${{ env.environment }}/serverless-app.tfstate"
-          dynamodb_table = "terraform-remote-state-lock-${{ variables.LICENSEPLATE }}"
+          bucket = "${{ vars.S3_BACKEND_NAME }}"
+          key = "${{ vars.LICENSEPLATE }}/${{ env.environment }}/serverless-app.tfstate"
+          dynamodb_table = "terraform-remote-state-lock-${{ vars.LICENSEPLATE }}"
           EOF
           terraform init -backend-config=backend.hcl
           terraform destroy -auto-approve
@@ -45,9 +45,9 @@ jobs:
         run: |
           cd client
           cat <<EOF > backend.hcl
-          bucket = "${{ variables.S3_BACKEND_NAME }}"
-          key = "${{ variables.LICENSEPLATE }}/${{ env.environment }}/serverless-app.tfstate"
-          dynamodb_table = "terraform-remote-state-lock-${{ variables.LICENSEPLATE }}"
+          bucket = "${{ vars.S3_BACKEND_NAME }}"
+          key = "${{ vars.LICENSEPLATE }}/${{ env.environment }}/serverless-app.tfstate"
+          dynamodb_table = "terraform-remote-state-lock-${{ vars.LICENSEPLATE }}"
           EOF
           terraform init -backend-config=backend.hcl
           terraform destroy -auto-approve

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          role-to-assume: ${{ secrets.TERRAFORM_DEPLOY_ROLE_ARN }}
+          role-to-assume: ${{ variables.TERRAFORM_DEPLOY_ROLE_ARN }}
           aws-region: ca-central-1
 
       - name: building the backend
@@ -42,14 +42,14 @@ jobs:
         run: |
 
           echo "**************"
-          echo "${{ secrets.LICENCEPLATE }}"
+          echo "${{ variables.LICENSEPLATE }}"
           echo "**************"
           
           cd server
           cat <<EOF > backend.hcl
-          bucket = "${{ secrets.S3_BACKEND_NAME }}"
-          key = "${{ secrets.LICENCEPLATE }}/${{ env.environment }}/serverless-app.tfstate"
-          dynamodb_table = "terraform-remote-state-lock-${{ secrets.LICENCEPLATE }}"
+          bucket = "${{ variables.S3_BACKEND_NAME }}"
+          key = "${{ variables.LICENSEPLATE }}/${{ env.environment }}/serverless-app.tfstate"
+          dynamodb_table = "terraform-remote-state-lock-${{ variables.LICENSEPLATE }}"
           EOF
           terraform init -backend-config=backend.hcl
           terraform plan
@@ -62,9 +62,9 @@ jobs:
           npm install
           CI=false npm run build
           cat <<EOF > backend.hcl
-          bucket = "${{ secrets.S3_BACKEND_NAME }}"
-          key = "${{ secrets.LICENCEPLATE }}/${{ env.environment }}/serverless-app.tfstate"
-          dynamodb_table = "terraform-remote-state-lock-${{ secrets.LICENCEPLATE }}"
+          bucket = "${{ variables.S3_BACKEND_NAME }}"
+          key = "${{ variables.LICENSEPLATE }}/${{ env.environment }}/serverless-app.tfstate"
+          dynamodb_table = "terraform-remote-state-lock-${{ variables.LICENSEPLATE }}"
           EOF
           terraform init -backend-config=backend.hcl
           terraform plan

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          role-to-assume: ${{ variables.TERRAFORM_DEPLOY_ROLE_ARN }}
+          role-to-assume: ${{ vars.TERRAFORM_DEPLOY_ROLE_ARN }}
           aws-region: ca-central-1
 
       - name: building the backend
@@ -42,14 +42,14 @@ jobs:
         run: |
 
           echo "**************"
-          echo "${{ variables.LICENSEPLATE }}"
+          echo "${{ vars.LICENSEPLATE }}"
           echo "**************"
           
           cd server
           cat <<EOF > backend.hcl
-          bucket = "${{ variables.S3_BACKEND_NAME }}"
-          key = "${{ variables.LICENSEPLATE }}/${{ env.environment }}/serverless-app.tfstate"
-          dynamodb_table = "terraform-remote-state-lock-${{ variables.LICENSEPLATE }}"
+          bucket = "${{ vars.S3_BACKEND_NAME }}"
+          key = "${{ vars.LICENSEPLATE }}/${{ env.environment }}/serverless-app.tfstate"
+          dynamodb_table = "terraform-remote-state-lock-${{ vars.LICENSEPLATE }}"
           EOF
           terraform init -backend-config=backend.hcl
           terraform plan
@@ -62,9 +62,9 @@ jobs:
           npm install
           CI=false npm run build
           cat <<EOF > backend.hcl
-          bucket = "${{ variables.S3_BACKEND_NAME }}"
-          key = "${{ variables.LICENSEPLATE }}/${{ env.environment }}/serverless-app.tfstate"
-          dynamodb_table = "terraform-remote-state-lock-${{ variables.LICENSEPLATE }}"
+          bucket = "${{ vars.S3_BACKEND_NAME }}"
+          key = "${{ vars.LICENSEPLATE }}/${{ env.environment }}/serverless-app.tfstate"
+          dynamodb_table = "terraform-remote-state-lock-${{ vars.LICENSEPLATE }}"
           EOF
           terraform init -backend-config=backend.hcl
           terraform plan

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          role-to-assume: ${{ variables.TERRAFORM_DEPLOY_ROLE_ARN }}
+          role-to-assume: ${{ vars.TERRAFORM_DEPLOY_ROLE_ARN }}
           aws-region: ca-central-1
 
       - name: building the backend
@@ -45,9 +45,9 @@ jobs:
         run: |
           cd server
           cat <<EOF > backend.hcl
-          bucket = "${{ variables.S3_BACKEND_NAME }}"
-          key = "${{ variables.LICENSEPLATE }}/${{ env.environment }}/serverless-app.tfstate"
-          dynamodb_table = "terraform-remote-state-lock-${{ variables.LICENSEPLATE }}"
+          bucket = "${{ vars.S3_BACKEND_NAME }}"
+          key = "${{ vars.LICENSEPLATE }}/${{ env.environment }}/serverless-app.tfstate"
+          dynamodb_table = "terraform-remote-state-lock-${{ vars.LICENSEPLATE }}"
           EOF
           terraform init -backend-config=backend.hcl
           terraform apply -auto-approve
@@ -60,9 +60,9 @@ jobs:
           npm install
           CI=false npm run build
           cat <<EOF > backend.hcl
-          bucket = "${{ variables.S3_BACKEND_NAME }}"
-          key = "${{ variables.LICENSEPLATE }}/${{ env.environment }}/serverless-app.tfstate"
-          dynamodb_table = "terraform-remote-state-lock-${{ variables.LICENSEPLATE }}"
+          bucket = "${{ vars.S3_BACKEND_NAME }}"
+          key = "${{ vars.LICENSEPLATE }}/${{ env.environment }}/serverless-app.tfstate"
+          dynamodb_table = "terraform-remote-state-lock-${{ vars.LICENSEPLATE }}"
           EOF
           terraform init -backend-config=backend.hcl
           terraform apply -auto-approve

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          role-to-assume: ${{ secrets.TERRAFORM_DEPLOY_ROLE_ARN }}
+          role-to-assume: ${{ variables.TERRAFORM_DEPLOY_ROLE_ARN }}
           aws-region: ca-central-1
 
       - name: building the backend
@@ -45,9 +45,9 @@ jobs:
         run: |
           cd server
           cat <<EOF > backend.hcl
-          bucket = "${{ secrets.S3_BACKEND_NAME }}"
-          key = "${{ secrets.LICENCEPLATE }}/${{ env.environment }}/serverless-app.tfstate"
-          dynamodb_table = "terraform-remote-state-lock-${{ secrets.LICENCEPLATE }}"
+          bucket = "${{ variables.S3_BACKEND_NAME }}"
+          key = "${{ variables.LICENSEPLATE }}/${{ env.environment }}/serverless-app.tfstate"
+          dynamodb_table = "terraform-remote-state-lock-${{ variables.LICENSEPLATE }}"
           EOF
           terraform init -backend-config=backend.hcl
           terraform apply -auto-approve
@@ -60,9 +60,9 @@ jobs:
           npm install
           CI=false npm run build
           cat <<EOF > backend.hcl
-          bucket = "${{ secrets.S3_BACKEND_NAME }}"
-          key = "${{ secrets.LICENCEPLATE }}/${{ env.environment }}/serverless-app.tfstate"
-          dynamodb_table = "terraform-remote-state-lock-${{ secrets.LICENCEPLATE }}"
+          bucket = "${{ variables.S3_BACKEND_NAME }}"
+          key = "${{ variables.LICENSEPLATE }}/${{ env.environment }}/serverless-app.tfstate"
+          dynamodb_table = "terraform-remote-state-lock-${{ variables.LICENSEPLATE }}"
           EOF
           terraform init -backend-config=backend.hcl
           terraform apply -auto-approve

--- a/.github/workflows/push_manual.yml
+++ b/.github/workflows/push_manual.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          role-to-assume: ${{ variables.TERRAFORM_DEPLOY_ROLE_ARN }}
+          role-to-assume: ${{ vars.TERRAFORM_DEPLOY_ROLE_ARN }}
           aws-region: ca-central-1
 
       - name: building the backend
@@ -43,9 +43,9 @@ jobs:
         run: |
           cd server
           cat <<EOF > backend.hcl
-          bucket = "${{ variables.S3_BACKEND_NAME }}"
-          key = "${{ variables.LICENSEPLATE }}/${{ env.environment }}/serverless-app.tfstate"
-          dynamodb_table = "terraform-remote-state-lock-${{ variables.LICENSEPLATE }}"
+          bucket = "${{ vars.S3_BACKEND_NAME }}"
+          key = "${{ vars.LICENSEPLATE }}/${{ env.environment }}/serverless-app.tfstate"
+          dynamodb_table = "terraform-remote-state-lock-${{ vars.LICENSEPLATE }}"
           EOF
           terraform init -backend-config=backend.hcl
           terraform apply -auto-approve
@@ -58,9 +58,9 @@ jobs:
           npm install
           CI=false npm run build
           cat <<EOF > backend.hcl
-          bucket = "${{ variables.S3_BACKEND_NAME }}"
-          key = "${{ variables.LICENSEPLATE }}/${{ env.environment }}/serverless-app.tfstate"
-          dynamodb_table = "terraform-remote-state-lock-${{ variables.LICENSEPLATE }}"
+          bucket = "${{ vars.S3_BACKEND_NAME }}"
+          key = "${{ vars.LICENSEPLATE }}/${{ env.environment }}/serverless-app.tfstate"
+          dynamodb_table = "terraform-remote-state-lock-${{ vars.LICENSEPLATE }}"
           EOF
           terraform init -backend-config=backend.hcl
           terraform apply -auto-approve

--- a/.github/workflows/push_manual.yml
+++ b/.github/workflows/push_manual.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          role-to-assume: ${{ secrets.TERRAFORM_DEPLOY_ROLE_ARN }}
+          role-to-assume: ${{ variables.TERRAFORM_DEPLOY_ROLE_ARN }}
           aws-region: ca-central-1
 
       - name: building the backend
@@ -43,9 +43,9 @@ jobs:
         run: |
           cd server
           cat <<EOF > backend.hcl
-          bucket = "${{ secrets.S3_BACKEND_NAME }}"
-          key = "${{ secrets.LICENCEPLATE }}/${{ env.environment }}/serverless-app.tfstate"
-          dynamodb_table = "terraform-remote-state-lock-${{ secrets.LICENCEPLATE }}"
+          bucket = "${{ variables.S3_BACKEND_NAME }}"
+          key = "${{ variables.LICENSEPLATE }}/${{ env.environment }}/serverless-app.tfstate"
+          dynamodb_table = "terraform-remote-state-lock-${{ variables.LICENSEPLATE }}"
           EOF
           terraform init -backend-config=backend.hcl
           terraform apply -auto-approve
@@ -58,9 +58,9 @@ jobs:
           npm install
           CI=false npm run build
           cat <<EOF > backend.hcl
-          bucket = "${{ secrets.S3_BACKEND_NAME }}"
-          key = "${{ secrets.LICENCEPLATE }}/${{ env.environment }}/serverless-app.tfstate"
-          dynamodb_table = "terraform-remote-state-lock-${{ secrets.LICENCEPLATE }}"
+          bucket = "${{ variables.S3_BACKEND_NAME }}"
+          key = "${{ variables.LICENSEPLATE }}/${{ env.environment }}/serverless-app.tfstate"
+          dynamodb_table = "terraform-remote-state-lock-${{ variables.LICENSEPLATE }}"
           EOF
           terraform init -backend-config=backend.hcl
           terraform apply -auto-approve

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.compile.nullAnalysis.mode": "disabled"
+}

--- a/README.md
+++ b/README.md
@@ -12,13 +12,15 @@ This repository use [Github OpenID Connect](https://docs.github.com/en/actions/d
 ## Setup
 - Fork this repo
 - Enable github actions
-#### Github Secrets
-you'll need to add two github secrets:
-  - `LICENCEPLATE` is the 6 character licensecho "x"e plate associated with your project set e.g. `abc123`
+#### Github Variables
+The GitHub actions require the following github variables:
+  - `LICENSEPLATE` is the 6 character alphanumeric string  associated with your project set e.g. `abc123` (Note: due to AWS constrains it is required the first characters is a letter)
   - `S3_BACKEND_NAME` is the name of the S3 Bucket name used to store the Terraform state.
   - `TERRAFORM_DEPLOY_ROLE_ARN` This is the ARN of IAM Role used to deploy resources through the Github action authenticate with the GitHub OpenID Connect. You also need to link that role to the correct IAM Policy.
-  - - To access the `TERRAFORM_DEPLOY_ROLE_ARN` you need to create it beforehand manually. To create it you need can use this example of thrust relationship :
-  - - The [minimal access policy can be found here](resources/deployement-policy.json)
+
+    - To access the `TERRAFORM_DEPLOY_ROLE_ARN` you need to create it beforehand manually. To create it you need can use this example of thrust relationship :
+    - The [minimal access policy can be found here](resources/deployement-policy.json) (Note: in the policy examples `<account-id>` has to be replaced by the AWS account id of the account where you are deploying the sample app)
+    - The role rewuires to have the following trust relationship set up  (Note: as before `<account-id>` has to be replaced by the AWS account id of the account where you are deploying the sample app)
   ```
   {
     "Version": "2012-10-17",
@@ -43,13 +45,13 @@ you'll need to add two github secrets:
 }
   ```
 
-  - Once the app has been built, you should be able to log into AWS with your IDIR account (2FA). Once in AWS search for Cloudfront and then click on Distributions (If you can not see it click the hamburger on the top left corner). The Distributions dashboard shows the Domain name, you can use that domain name to interact with you app.
+  - Once the app has been built, you should be able to log into AWS with your IDIR account (2FA may be implemented). Once logged in AWS search for Cloudfront and then click on Distributions (If you can not see it click the hamburger on the top left corner). The Distributions dashboard shows the Domain name url, you can use that url to open a browser session and load the app.
 
 
 #### Pipeline
 The github actions will trigger on a pull request creation and merge.
-- Creating a pull request will run a `terraform plan` and outline everything that will be deployed into your AWS accounts, but will not create anything.
-- Merging into `main` will run a `terraform apply` and your AWS assets will be deployed into your `dev` and `sandbox` accounts.
+- Creating a pull request will run a `terraform plan` and outline everything that will be deployed into your AWS accounts, but will not create anything. Please review the plan to verify that all is correct.
+- Merging into `main` will run a `terraform apply` and your AWS assets will be deployed in the `dev` accounts.
 
 NOTE: make sure you are creating pull requests/ merging within your fork
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The GitHub actions require the following github variables:
 
     - To access the `TERRAFORM_DEPLOY_ROLE_ARN` you need to create it beforehand manually. To create it you need can use this example of thrust relationship :
     - The [minimal access policy can be found here](resources/deployement-policy.json) (Note: in the policy examples `<account-id>` has to be replaced by the AWS account id of the account where you are deploying the sample app)
-    - The role rewuires to have the following trust relationship set up  (Note: as before `<account-id>` has to be replaced by the AWS account id of the account where you are deploying the sample app)
+    - The role requires to have the following trust relationship set up  (Note: as before `<account-id>` has to be replaced by the AWS account id of the account where you are deploying the sample app)
   ```
   {
     "Version": "2012-10-17",

--- a/client/src/components/form/Greeter.js
+++ b/client/src/components/form/Greeter.js
@@ -41,7 +41,7 @@ console.log(values)
             options={[
               { value: 'Aloha', label: 'Aloha' },
               { value: 'Bonjour', label: 'Bonjour' },
-              { value: 'Greetings and salutations', label: 'Greetings and salutations' },
+              { value: 'Greetings and salutations', label: 'o20ya1 - after changing secrets to vars - April 19, 2023' },
               { value: 'Hello', label: 'Hello' },
               { value: 'Howdy', label: 'Howdy' },
               { value: 'Konichiwa', label: 'Konichiwa' },

--- a/client/src/components/form/Greeter.js
+++ b/client/src/components/form/Greeter.js
@@ -41,7 +41,7 @@ console.log(values)
             options={[
               { value: 'Aloha', label: 'Aloha' },
               { value: 'Bonjour', label: 'Bonjour' },
-              { value: 'Greetings and salutations', label: 'o20ya1 - after changing secrets to vars - April 19, 2023' },
+              { value: 'Greetings and salutations', label: 'Greetings and salutations' },
               { value: 'Hello', label: 'Hello' },
               { value: 'Howdy', label: 'Howdy' },
               { value: 'Konichiwa', label: 'Konichiwa' },

--- a/functional-tests/.project
+++ b/functional-tests/.project
@@ -20,4 +20,15 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1681924204544</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/functional-tests/Readme.md
+++ b/functional-tests/Readme.md
@@ -5,23 +5,18 @@ Under `functional_test` folder you will find a set of scripts to run an automate
 The app is written in groovy using the geb/spock framework. This framework makes the test easy to read and to follow.
 
 ## Run the test
-As currently written, the BASEURL is read from the environment, so, when running locally.  first set this value by typing on the command line 
-`export BASEURL="https://d3qkdfho08icid.cloudfront.net/"`
+As currently written, the BASEURL is read from the environment, so, when running the script locally, first set this value by typing on the command line 
+`export BASEURL="https://a1bdcedg23h1jkl.cloudfront.net/"`
 
-The find the specific address you need to log into Cloudfront after installing the application. 
+The find the url for the serverless app, once the app has been deployed, log in AWS console, using the AWS account credentials and open the Cloudfront console. 
 
-To run the test, open terminal and navigate to `.../functional-test` and execute 
+To run the test, open terminal and navigate to `../functional-test` and execute 
 `./gradlew chromeTest --tests="FirstTest"`
 
 Alternatively, you can hardcode the address in the GebConfig.groovy file
 
-To run the test, cd to `functional-tests` folder type on terminal
 
-  `./gradlew chromeTest --tests="FirstTest"`
-
-
-
-When running the test in GitHub actions, set the BASEURL as a GitHub secret
+When running the test in GitHub actions, set the BASEURL as a GitHub variable
 
 
 ## Reports
@@ -45,11 +40,11 @@ and with some manipulation find the BASEURL. Unfortunately, this does not work w
 When using BrowserStack, the test scripts are running locally in your machine (or in GitHub) firing a remote browser in BrowserStack, in this case on the BrowserStack cloud, and the browser is opening the containers app page stored in AWS
 
 For this configuration you need 
-- The sample serverless app installed in AWS. You also need the license plate (check `startup-sample-project-aws-serverless/Readme.md` for more information)
+- The sample serverless app installed in AWS. You also need the license plate,  (check `startup-sample-project-aws-serverless/Readme.md` for more information)
 
 - An account with BrowserStack, once you have the account, you will access the values of `User Name` and `Access Key`. To run the test locally, you will need to type in terminal the following commands to add their values in your environment
 
-  `export LICENSE_PLATE=[LICENSE PLATE]`
+  `export LICENSE_PLATE=[LICENSEPLATE]`
   
   `export BROWSERSTACK_USERNAME=[BrowserStack user name]`
   
@@ -69,12 +64,12 @@ Currently it is not possible to run the test automatically in a CI/CD GiHub Acti
 
 Currently, the manually triggered action `AutomationTestUbuntu.yml` runs automatically the tests in GitHub and `browserStackTest.yml` to run the test using BrowserStack
 
-The following secrets need to be set to run the test:
+The following GitHub secrets need to be set to run the test:
 
 - `BROWSERSTACK_ACCESS_KEY`
 - `BROWSERSTACK_USERNAME`
 
-The following secrets need to be set to mail the test results to the account of your choice (You may comment out the section that sends the eamil in the yml script)
+The following GitHub secrets need to be set to mail the test results to the account of your choice (You may comment out the section that sends the eamil in the yml script)
 - `MAIL_ADDRESS`
 - `MAIL_PASSWORD`
 - `MAIL_SERVER`


### PR DESCRIPTION
I have updated the github workflows to use variables (vars) instead of secrets. Also updated the Redme file.

Using the vars_from_secrets  branch I have been able to successfully destroy and then redeploy the serverless sample app. The new url is https://dhxdodynx1syg.cloudfront.net/ and one of the greetings message has been altered to show it is using vars instead of secrets. Secrets have been removed from the Settings and replaced by variables